### PR TITLE
Migrate manifest to project dir

### DIFF
--- a/tasks/sendwithus.coffee
+++ b/tasks/sendwithus.coffee
@@ -49,7 +49,7 @@ class Sendwithus
     @apiKey = apiKey
     @debug = debug
 
-    @indexFile = normalize("#{getUserHome()}/#{pkg.name}.json")
+    @indexFile = normalize("#{pkg.name}.json")
     @indexContents = @getIndexContents()
 
   # Generate an MD5 hash from an arbitrary string
@@ -114,11 +114,18 @@ class Sendwithus
   getIndexContents: () ->
     # Check if the local cache file exists or not
     if not grunt.file.exists @indexFile
-      grunt.log.ok "Cache file doesn't exist, creating…"
-      grunt.file.write @indexFile, '[]' # write a blank file with an array for valid JSON
+      grunt.log.ok "Cache file doesn't exist"
+      legacyPath = "#{getUserHome()}/#{pkg.name}.json"
+      if grunt.file.exists legacyPath
+        legacyContents = grunt.file.readJSON legacyPath
+        grunt.log.ok "Found legacy manifest, creating project manifest"
+        @writeIndexContents(legacyContents)
+      else
+        grunt.log.ok "Creating project manifest"
+        grunt.file.write @indexFile, '[]' # write a blank file with an array for valid JSON
     else
       grunt.log.ok 'Cache file exists, continuing…'
-
+    grunt.fail.warn "bailing out, cause testing"
     # Read the contents of the index file
     return grunt.file.readJSON @indexFile
 

--- a/tasks/sendwithus.coffee
+++ b/tasks/sendwithus.coffee
@@ -125,7 +125,6 @@ class Sendwithus
         grunt.file.write @indexFile, '[]' # write a blank file with an array for valid JSON
     else
       grunt.log.ok 'Cache file exists, continuing…'
-    grunt.fail.warn "bailing out, cause testing"
     # Read the contents of the index file
     return grunt.file.readJSON @indexFile
 


### PR DESCRIPTION
Migrates the manifest file to the project directory so it can be checked in to version control and shared between team members.

The current manifest file is stored in the home directory.  It works for just one person, but if you're working with a team things quickly get out of sync and devs start duplicating templates all over the place just because their manifest isn't updated.

This PR stores the manifest in the project directory instead.  It has a migration built in so that if a manifest exists in the home directory it copies it over to the project instead of initializing an empty one.